### PR TITLE
fix: restore Enea portal downloads

### DIFF
--- a/enea_client/client.py
+++ b/enea_client/client.py
@@ -7,7 +7,7 @@ import urllib.parse
 from http import HTTPStatus
 from typing import TYPE_CHECKING, TypedDict
 
-from enea_client.utils.connection import open_connection
+from enea_client.utils.connection import get_cookie_header, open_connection
 
 if TYPE_CHECKING:
     from enea_client.config import Config
@@ -21,6 +21,7 @@ class Response(TypedDict, total=False):
 class Client:
     def __init__(self, config: Config) -> None:
         self.config = config
+        self.session_cookie_name = "EBOK_SESSION"
         self.signed_cookie: str = ""
 
     def authenticate(self) -> bool:
@@ -57,6 +58,7 @@ class Client:
                 headers={
                     "Content-type": "application/x-www-form-urlencoded",
                     "Cookie": self.signed_cookie,
+                    "User-Agent": self.config.enea_user_agent,
                 },
             )
 
@@ -84,16 +86,18 @@ class Client:
                 logger.error("Error: status - %s, reason - %s", response.status, response.reason)
                 return None
 
-            cookie = response.getheader("Set-Cookie")
-
-            if cookie is None:
-                logger.error("Error: No cookie")
+            session_cookie = get_cookie_header(
+                response.headers.get_all("Set-Cookie"),
+                self.session_cookie_name,
+            )
+            if session_cookie is None:
+                logger.error("Error: %s cookie not found", self.session_cookie_name)
                 return None
 
             body = response.read().decode()
             token = re.findall(r'name="token" value="([^"]+)"', body)[0]
 
-            return cookie, token
+            return session_cookie, token
 
     def _sign_session(self, cookie: str, token: str) -> str | None:
         with open_connection(self.config.enea_url, self.config.connection_timeout) as connection:
@@ -116,4 +120,21 @@ class Client:
                 logger.error("Error: status - %s, reason - %s", response.status, response.reason)
                 return None
 
-            return response.getheader("Set-Cookie")
+            session_cookie = get_cookie_header(
+                response.headers.get_all("Set-Cookie"),
+                self.session_cookie_name,
+            )
+            if session_cookie is None:
+                logger.error("Error: %s cookie not found", self.session_cookie_name)
+                return None
+
+            connection.request(
+                "GET",
+                "/dashboard",
+                headers={
+                    "Cookie": session_cookie,
+                    "User-Agent": self.config.enea_user_agent,
+                },
+            )
+
+            return session_cookie

--- a/enea_client/config.py
+++ b/enea_client/config.py
@@ -15,4 +15,9 @@ class Config:
 
     connection_timeout: int = 60
     enea_url: str = "https://ebok.enea.pl"
+    enea_user_agent: str = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/148.0.0.0 Safari/537.36"
+    )
     enea_timezone: ZoneInfo = field(default_factory=lambda: ZoneInfo("Europe/Warsaw"))

--- a/enea_client/utils/connection.py
+++ b/enea_client/utils/connection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import http.client as http_client
 import logging
 from contextlib import contextmanager
+from http.cookies import SimpleCookie
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -33,3 +34,18 @@ def open_connection(url: str, timeout: int) -> Generator[http_client.HTTPConnect
         yield connection
     finally:
         connection.close()
+
+
+def get_cookie_header(cookies_list: list[str] | None, cookie_name: str) -> str | None:
+    cookie_jar = SimpleCookie()
+
+    if cookies_list is None:
+        return None
+
+    for cookie in cookies_list:
+        cookie_jar.load(cookie)
+
+    if cookie_name not in cookie_jar:
+        return None
+
+    return cookie_jar[cookie_name].OutputString(attrs=[])

--- a/scripts/enea_client.service
+++ b/scripts/enea_client.service
@@ -6,4 +6,4 @@ Type=oneshot
 EnvironmentFile=/home/zbigniew/bin/enea-client/.env
 WorkingDirectory=/home/zbigniew/bin/enea-client
 
-ExecStart=/bin/bash -c 'CURRENT=$$(date +%%m.%%Y); PREVIOUS=$$(date -d "last month" +%%m.%%Y); exec /usr/bin/python -m enea_client --dates="$${PREVIOUS},$${CURRENT}" --post-process-script=scripts/post_process_script.sh'
+ExecStart=/bin/bash -c 'CURRENT=$$(date +%%m.%%Y); PREVIOUS=$$(date -d "$$(date +%%Y-%%m-01) -1 month" +%%m.%%Y); exec /usr/bin/python -m enea_client --dates="$${PREVIOUS},$${CURRENT}" --post-process-script=scripts/post_process_script.sh'

--- a/scripts/post_process_script.sh
+++ b/scripts/post_process_script.sh
@@ -27,6 +27,9 @@ for input in "${inputs[@]}"; do
   ' "$input" >> "$output_dir/$output_file"
 done
 
+# Adjust the DST-overlap timestamp in the generated CSV before import.
+sed -i 's/2026-03-29 02:00/2026-03-29 01:00/g' "$output_dir/$output_file"
+
 # Run the curl command to import the processed CSV file into Home Assistant
 curl -X POST \
    -H "Authorization: Bearer $ENEA_CLIENT_POST_PROCESS_HOME_ASSISTANT_TOKEN" \
@@ -36,7 +39,7 @@ curl -X POST \
     "filename": "'"$output_file"'",
     "timezone_identifier": "Europe/Warsaw",
     "delimiter": ",",
-    "decimal": false,
+    "decimal": ".",
     "datetime_format": "%Y-%m-%d %H:%M",
     "unit_from_entity": false
   }'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,7 +19,7 @@ def test_client_aithenticate_success(httpserver: HTTPServer, config: Config) -> 
         '<input type="hidden" name="token" value="token-123">',
         status=HTTPStatus.OK,
         headers={
-            "Set-Cookie": "SESSION=unsigned; Path=/; HttpOnly",
+            "Set-Cookie": "EBOK_SESSION=unsigned; Path=/; HttpOnly",
             "Content-Type": "text/html",
         },
     )
@@ -28,14 +28,19 @@ def test_client_aithenticate_success(httpserver: HTTPServer, config: Config) -> 
         "",
         status=HTTPStatus.FOUND,
         headers={
-            "Set-Cookie": "SESSION=signed; Path=/; HttpOnly",
+            "Set-Cookie": "EBOK_SESSION=signed; Path=/; HttpOnly",
             "Location": "/",
         },
     )
 
+    httpserver.expect_request("/dashboard", method="GET").respond_with_data(
+        "",
+        status=HTTPStatus.OK,
+    )
+
     client = Client(config)
     assert client.authenticate() is True
-    assert client.signed_cookie == "SESSION=signed; Path=/; HttpOnly"
+    assert client.signed_cookie == "EBOK_SESSION=signed"
 
 def test_client_authenticate_session_none(config: Config, httpserver: HTTPServer) -> None:
     config.enea_url = httpserver.url_for("")
@@ -56,7 +61,7 @@ def test_client_authenticate_signed_cookie_none(config: Config, httpserver: HTTP
         '<input type="hidden" name="token" value="token-123">',
         status=HTTPStatus.OK,
         headers={
-            "Set-Cookie": "SESSION=unsigned; Path=/; HttpOnly",
+            "Set-Cookie": "EBOK_SESSION=unsigned; Path=/; HttpOnly",
             "Content-Type": "text/html",
         },
     )
@@ -69,6 +74,40 @@ def test_client_authenticate_signed_cookie_none(config: Config, httpserver: HTTP
     client = Client(config)
     assert client.authenticate() is False
     assert client.signed_cookie == ""
+
+def test_client_authenticate_signed_cookie_not_found(
+    config: Config,
+    httpserver: HTTPServer,
+    caplog: LogCaptureFixture,
+) -> None:
+    config.enea_url = httpserver.url_for("")
+
+    httpserver.expect_request("/logowanie", method="GET").respond_with_data(
+        '<input type="hidden" name="token" value="token-123">',
+        status=HTTPStatus.OK,
+        headers={
+            "Set-Cookie": "EBOK_SESSION=unsigned; Path=/; HttpOnly",
+            "Content-Type": "text/html",
+        },
+    )
+
+    httpserver.expect_request("/logowanie", method="POST").respond_with_data(
+        "",
+        status=HTTPStatus.FOUND,
+        headers={
+            "Set-Cookie": "OTHER_SESSION=signed; Path=/; HttpOnly",
+            "Location": "/",
+        },
+    )
+
+    client = Client(config)
+
+    with caplog.at_level(logging.ERROR):
+        result = client.authenticate()
+
+    assert result is False
+    assert client.signed_cookie == ""
+    assert "Error: EBOK_SESSION cookie not found" in caplog.text
 
 def test_client_authenticate_no_cookie(config: Config, httpserver: HTTPServer, caplog: LogCaptureFixture) -> None:
     config.enea_url = httpserver.url_for("")
@@ -88,7 +127,7 @@ def test_client_authenticate_no_cookie(config: Config, httpserver: HTTPServer, c
 
     assert result is False
     assert client.signed_cookie == ""
-    assert "Error: No cookie" in caplog.text
+    assert "Error: EBOK_SESSION cookie not found" in caplog.text
 
 def test_client_get_data_success(config: Config, httpserver: HTTPServer) -> None:
     data = (


### PR DESCRIPTION
Parse EBOK_SESSION from Set-Cookie headers and reuse the stripped cookie value for login and data requests. Send the portal user agent and load the dashboard after sign-in to complete the new auth flow.

Adjust Home Assistant post-processing for the DST-overlap timestamp and decimal separator. Update client auth tests for the new cookie handling while keeping coverage at 100%.

Fixes #7 